### PR TITLE
Expose mount_point/location_id

### DIFF
--- a/gilrs-core/src/lib.rs
+++ b/gilrs-core/src/lib.rs
@@ -165,6 +165,12 @@ impl Gamepad {
         *self.inner.uuid().as_bytes()
     }
 
+    /// Returns dev path or location id which represents the unique io location of the gamepad in Macos or Windows.
+    /// Always None in other platforms.
+    pub fn mount_point(&self) -> Option<String> {
+        self.inner.mount_point()
+    }
+
     /// Returns device's power supply state.
     pub fn power_info(&self) -> PowerInfo {
         self.inner.power_info()

--- a/gilrs-core/src/platform/linux/gamepad.rs
+++ b/gilrs-core/src/platform/linux/gamepad.rs
@@ -686,6 +686,10 @@ impl Gamepad {
         }
     }
 
+    pub fn mount_point(&self) -> Option<String> {
+        Some(self.devpath)
+    }
+
     pub fn buttons(&self) -> &[EvCode] {
         &self.buttons
     }

--- a/gilrs-core/src/platform/macos/gamepad.rs
+++ b/gilrs-core/src/platform/macos/gamepad.rs
@@ -303,6 +303,11 @@ impl Gamepad {
         false
     }
 
+    pub fn mount_point(&self) -> Option<String> {
+        let location_id = self.location_id.to_string();
+        Some(location_id)
+    }
+
     /// Creates Ffdevice corresponding to this gamepad.
     pub fn ff_device(&self) -> Option<FfDevice> {
         Some(FfDevice)

--- a/gilrs-core/src/platform/wasm/gamepad.rs
+++ b/gilrs-core/src/platform/wasm/gamepad.rs
@@ -244,6 +244,10 @@ impl Gamepad {
         self.uuid
     }
 
+    pub fn mount_point(&self) -> Option<String> {
+        None
+    }
+
     pub fn is_connected(&self) -> bool {
         self.gamepad.connected()
     }

--- a/gilrs-core/src/platform/windows/gamepad.rs
+++ b/gilrs-core/src/platform/windows/gamepad.rs
@@ -390,6 +390,10 @@ impl Gamepad {
         self.uuid
     }
 
+    pub fn mount_point(&self) -> Option<String> {
+        None
+    }
+
     pub fn is_connected(&self) -> bool {
         self.is_connected
     }

--- a/gilrs/src/gamepad.rs
+++ b/gilrs/src/gamepad.rs
@@ -767,6 +767,12 @@ impl<'a> Gamepad<'a> {
         self.inner.uuid()
     }
 
+    /// Returns dev path or location id which represents the unique io location of the gamepad in Macos or Windows.
+    /// Always None in other platforms.
+    pub fn mount_point(&self) -> Option<String> {
+        self.inner.mount_point()
+    }
+
     /// Returns cached gamepad state.
     pub fn state(&self) -> &GamepadState {
         &self.data.state


### PR DESCRIPTION
This exposes the devpath in Linux and the location_Id within Macos corresponding to where the controller is mounted. In WASM and Windows which operate differently and don't expose their mounts to gilrs, calling mount_point simply returns None. 